### PR TITLE
chore: replace raw echo/curl/jq/head/tail/xargs/rm -f with p6 stdlib wrappers

### DIFF
--- a/lib/cfg/_gen.sh
+++ b/lib/cfg/_gen.sh
@@ -8,8 +8,8 @@
 p6_aws_cfg__generate() {
 
     local var
-    rm -f lib/env/*.sh
-    rm -f t/cfg-*.t
+    p6_file_rmf "lib/env/*.sh"
+    p6_file_rmf "t/cfg-*.t"
 
     for var in $(p6_aws_cfg_vars | p6_filter_sort); do
         local var_norm=$(p6_string_lc "$var")

--- a/lib/svc/cloudwatch/lambda.sh
+++ b/lib/svc/cloudwatch/lambda.sh
@@ -16,9 +16,9 @@ p6_aws_svc_logs_lambda_watch_jq() {
         while read -r line; do
 	    if p6_string_contains "$line" "}"; then
               json=$(p6_echo "$line" | p6_filter_extract_after "{" | p6_filter_translate_start_to_arg "{")
-	      echo "$json" | jq "."
+	      p6_echo "$json" | p6_json_eval "."
             else
-              echo "$line"
+              p6_echo "$line"
             fi
         done
 }

--- a/lib/svc/cloudwatch/trail.sh
+++ b/lib/svc/cloudwatch/trail.sh
@@ -16,7 +16,7 @@ p6_aws_svc_logs_trail_watch_jq() {
         while read -r line; do
             json=$(p6_echo "$line" | p6_filter_extract_after "{" | p6_filter_translate_start_to_arg "{")
             echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-            echo "$json" | jq '.'
+            p6_echo "$json" | p6_json_eval '.'
             echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
         done
 }

--- a/lib/svc/dynamodb/table.sh
+++ b/lib/svc/dynamodb/table.sh
@@ -9,7 +9,7 @@ p6_aws_svc_dynamodb_tables_list() {
 
   p6_aws_cli_cmd dynamodb list-tables \
     --query "'TableNames[]'" | \
-    jq -r ".[]"
+    p6_json_eval -r ".[]"
 }
 
 ######################################################################
@@ -47,5 +47,5 @@ p6_aws_svc_dynamodb_table_all() {
   p6_aws_cli_cmd dynamodb scan \
     --table-name "$table_name" \
     --query "'Items[]'" |
-    jq -c '.[]'
+    p6_json_eval -c '.[]'
 }

--- a/lib/svc/ec2/ami.sh
+++ b/lib/svc/ec2/ami.sh
@@ -145,7 +145,7 @@ p6_aws_svc_ec2_ami_find_id() {
 		--filters "Name=name,Values=$glob" \
 		--query "Images[*].[Name,ImageId]" |
 		p6_filter_sort_by_column 1 |
-		tail -1 |
+		p6_filter_row_last 1 |
 		p6_filter_extract_after "ami-" | p6_filter_translate_start_to_arg "ami-"
 	)
 
@@ -186,7 +186,7 @@ p6_aws_svc_ec2_ami_find_amazon2_latest() {
 		--query "'Images[].[ImageId]'" \
 		--filters "'Name=name,Values=amzn2-ami-hvm-*gp2'" |
 		p6_filter_sort_reverse_by_column 1 |
-		tail -1)
+		p6_filter_row_last 1)
 
 	p6_return_str "$ami_id"
 }

--- a/lib/svc/ec2/subnet.sh
+++ b/lib/svc/ec2/subnet.sh
@@ -14,7 +14,7 @@ p6_aws_svc_ec2_subnet_get() {
     local vpc_id="$2"
 
     local subnet_id
-    subnet_id=$(p6_aws_svc_ec2_subnet_ids_get "$subnet_type" "$vpc_id" | head -1)
+    subnet_id=$(p6_aws_svc_ec2_subnet_ids_get "$subnet_type" "$vpc_id" | p6_filter_row_first 1)
 
     p6_return_aws_subnet_id "$subnet_id"
 }

--- a/lib/svc/glue/crawlers.sh
+++ b/lib/svc/glue/crawlers.sh
@@ -14,8 +14,8 @@ p6_aws_svc_glue_crawlers_arn_list() {
 
     while ! p6_string_eq "$next_token" "null"; do
         p6_aws_cli_cmd glue list-crawlers >$dir/crawlers.json
-        next_token=$(cat $dir/crawlers.json | jq -r ".NextToken")
-        p6_file_display "$dir/crawlers.json" | jq -r ".CrawlerNames"
+        next_token=$(p6_json_from_file "$dir/crawlers.json" | p6_json_eval -r ".NextToken")
+        p6_json_from_file "$dir/crawlers.json" | p6_json_eval -r ".CrawlerNames"
     done | p6_filter_row_exclude "\\[" |
         p6_filter_row_exclude "\\]" |
         p6_filter_strip_chars '",'

--- a/lib/svc/organizations/account.sh
+++ b/lib/svc/organizations/account.sh
@@ -64,7 +64,7 @@ p6_aws_svc_organizations_accounts_list_active_ids() {
 ######################################################################
 p6_aws_svc_organizations_accounts_list_active_ids_as_list() {
 
-  local account_ids=$(p6_aws_svc_organizations_accounts_list_active_ids | xargs)
+  local account_ids=$(p6_aws_svc_organizations_accounts_list_active_ids | p6_filter_join_words)
 
   p6_return_words "$account_ids"
 }
@@ -82,7 +82,7 @@ p6_aws_svc_organizations_accounts_list_active_ids_as_list() {
 p6_aws_svc_organizations_account_list_active_ids_without_management() {
 
   local management_account_id=$(p6_aws_svc_organization_management_account_id_get)
-  local account_ids=$(p6_aws_svc_organizations_accounts_list_active_ids | p6_filter_row_exclude "$management_account_id" | xargs)
+  local account_ids=$(p6_aws_svc_organizations_accounts_list_active_ids | p6_filter_row_exclude "$management_account_id" | p6_filter_join_words)
 
   p6_return_words "$account_ids"
 }

--- a/lib/svc/route53domains/domain.sh
+++ b/lib/svc/route53domains/domain.sh
@@ -106,5 +106,5 @@ p6_aws_svc_route53_domains_nameservers_delta() {
     p6_aws_svc_route53_domains_nameservers_whois "$domain_name" >/tmp/p6-2
 
     diff -u /tmp/p6-1 /tmp/p6-2
-    rm -f /tmp/p6-1 /tmp/p6-2
+    p6_file_rmf "/tmp/p6-1"; p6_file_rmf "/tmp/p6-2"
 }

--- a/lib/svc/sts/account.sh
+++ b/lib/svc/sts/account.sh
@@ -12,7 +12,7 @@
 ######################################################################
 p6_aws_svc_sts_account_id() {
 
-    local account_id=$(p6_aws_svc_sts_whoami | jq -r ".Account")
+    local account_id=$(p6_aws_svc_sts_whoami | p6_json_eval -r ".Account")
 
     p6_return_aws_account_id "$account_id"
 }

--- a/lib/svc/sts/decode.sh
+++ b/lib/svc/sts/decode.sh
@@ -15,7 +15,7 @@
 p6_aws_svc_sts_decode_msg() {
     local encoded="$1"
 
-    p6_aws_cli_cmd sts decode-message | jq -r '.DecodeMessage' | jq .
+    p6_aws_cli_cmd sts decode-message | p6_json_eval -r '.DecodeMessage' | p6_json_eval .
 
     p6_return_stream
 }

--- a/lib/svc/sts/identity.sh
+++ b/lib/svc/sts/identity.sh
@@ -49,24 +49,24 @@ p6_aws_svc_sts_identity_broker_custom_login_url() {
 
     # url encode str
     local session
-    session=$(echo "$str" | jq -sRr @uri)
+    session=$(p6_echo "$str" | p6_json_eval -sRr @uri)
 
     # getSigninToken request
     local response
-    response=$(curl -s "$federation_endpoint?Action=getSigninToken&SessionDuration=1800&Session=$session")
+    response=$(p6_curl -s "$federation_endpoint?Action=getSigninToken&SessionDuration=1800&Session=$session")
 
     # grab SigninToken
     local signin_token
-    signin_token=$(echo "$response" | jq -r ".SigninToken")
+    signin_token=$(p6_echo "$response" | p6_json_eval -r ".SigninToken")
 
     # login request
     local destination
     local issuer
-    destination=$(echo "$console_endpoint" | jq -Rr @uri)
-    issuer=$(echo "p6cli" | jq -rR @uri)
+    destination=$(p6_echo "$console_endpoint" | p6_json_eval -Rr @uri)
+    issuer=$(p6_echo "p6cli" | p6_json_eval -rR @uri)
 
     local login_url
     login_url="$federation_endpoint?Action=login&Issuer=$issuer&Destination=$destination&SigninToken=$signin_token"
 
-    echo "$login_url"
+    p6_echo "$login_url"
 }


### PR DESCRIPTION
## Summary

Replace raw shell primitives with p6common stdlib functions across multiple service files:

- **Issues 6**: `echo/jq` in `cloudwatch/trail.sh`, `cloudwatch/lambda.sh` → `p6_msg`/`p6_echo`/`p6_json_eval`
- **Issue 7**: `cat/jq` in `glue/crawlers.sh`, `dynamodb/table.sh`, `sts/account.sh`, `sts/decode.sh` → `p6_json_from_file`/`p6_json_eval`
- **Issue 8**: `echo/curl/jq` in `sts/identity.sh` → `p6_echo`/`p6_curl`/`p6_json_eval`
- **Issue 9**: `head -1`/`tail -1` in `ec2/subnet.sh`, `ec2/ami.sh` → `p6_filter_row_first`/`p6_filter_row_last`
- **Issue 10**: `| xargs` in `organizations/account.sh` → `p6_filter_join_words`
- **Issue 11**: `rm -f` in `cfg/_gen.sh`, `route53domains/domain.sh` → `p6_file_rmf`

## Test plan

- [ ] `p6_aws_svc_logs_trail_watch_jq` outputs JSON with proper formatting
- [ ] `p6_aws_svc_sts_identity_broker_custom_login_url` builds login URL correctly
- [ ] `p6_aws_svc_glue_crawlers_arn_list` paginates correctly
- [ ] `p6_aws_svc_dynamodb_tables_list` returns table names
- [ ] `p6_aws_svc_sts_account_id` returns account ID
- [ ] `p6_aws_svc_ec2_subnet_get` returns first subnet
- [ ] `p6_aws_svc_ec2_ami_find_id` returns latest AMI
- [ ] `p6_aws_svc_organizations_accounts_list_active_ids_as_list` returns space-joined IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)