### PR TITLE
fix: migrate p6_json_eval callers to stdin/pipe pattern

### DIFF
--- a/lib/svc/organizations/sts.sh
+++ b/lib/svc/organizations/sts.sh
@@ -131,9 +131,9 @@ p6_aws_svc_organizations_sts_github_su() {
   new_arn="arn:aws:iam::${account_id}:role/OrganizationAccountAccessRole"
 
   local json=$(p6_aws_cli_cmd sts assume-role --role-arn "$new_arn" --role-session-name "$role_session_name")
-  local access_key_id=$(p6_json_eval "$json" "-r" ".Credentials.AccessKeyId")
-  local secret_access_key=$(p6_json_eval "$json" "-r" ".Credentials.SecretAccessKey")
-  local session_token=$(p6_json_eval "$json" "-r" ".Credentials.SessionToken")
+  local access_key_id=$(p6_echo "$json" | p6_json_eval -r ".Credentials.AccessKeyId")
+  local secret_access_key=$(p6_echo "$json" | p6_json_eval -r ".Credentials.SecretAccessKey")
+  local session_token=$(p6_echo "$json" | p6_json_eval -r ".Credentials.SessionToken")
 
   export PRIOR_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
   export PRIOR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY

--- a/lib/svc/sts/role.sh
+++ b/lib/svc/sts/role.sh
@@ -77,10 +77,10 @@ p6_aws_svc_sts_role_credentials_on() {
     name="$org-$type"
 
     # Parse
-    access_key_id=$(p6_json_eval "$json" "-r" ".Credentials.AccessKeyId")
-    secret_access_key=$(p6_json_eval "$json" "-r" ".Credentials.SecretAccessKey")
-    session_token=$(p6_json_eval "$json" "-r" ".Credentials.SessionToken")
-    expiration=$(p6_json_eval "$json" "-r" ".Credentials.Expiration")
+    access_key_id=$(p6_echo "$json" | p6_json_eval -r ".Credentials.AccessKeyId")
+    secret_access_key=$(p6_echo "$json" | p6_json_eval -r ".Credentials.SecretAccessKey")
+    session_token=$(p6_echo "$json" | p6_json_eval -r ".Credentials.SessionToken")
+    expiration=$(p6_echo "$json" | p6_json_eval -r ".Credentials.Expiration")
 
     # Mock the New Env
     p6_aws_cfg_save_source


### PR DESCRIPTION
## Summary
- `p6_json_eval` in p6common now accepts JSON via stdin (not first arg)
- Update pre-existing callers in `organizations/sts.sh` and `sts/role.sh` from `p6_json_eval "$json" "-r" "..."` to `p6_echo "$json" | p6_json_eval -r "..."`

## Test plan
- [ ] `p6_aws_svc_organizations_account_assume_role` correctly extracts credentials
- [ ] `p6_aws_svc_sts_role_*` correctly extracts access key, secret, session token, expiration

🤖 Generated with [Claude Code](https://claude.com/claude-code)